### PR TITLE
Small bug fixes

### DIFF
--- a/src/alveoleye/_action_box.py
+++ b/src/alveoleye/_action_box.py
@@ -8,7 +8,12 @@ from alveoleye._workers import WorkerParent
 
 class ActionBox(QGroupBox):
     current_results = []
-    file_name = None
+
+    import_paths = {
+        "image": None,
+        "weights": None
+    }
+
     all_action_boxes = []
     step = 0
 

--- a/src/alveoleye/_boxes.py
+++ b/src/alveoleye/_boxes.py
@@ -417,8 +417,8 @@ class AssessmentsActionBox(ActionBox):
                                         assessments_layer, True)
 
         ActionBox.current_results = [os.path.basename(ActionBox.import_paths["image"]),
-                                     os.path.basename(ActionBox.import_paths["weights"]), asvd, mli, chords,
-                                     stdev_chord_lengths, airspace_pixels, non_airspace_pixels,
+                                     os.path.basename(ActionBox.import_paths["weights"]), asvd, mli,
+                                     stdev_chord_lengths, chords, airspace_pixels, non_airspace_pixels,
                                      self.lines_spin_box.value(), self.min_length_spin_box.value(),
                                      self.scale_spin_box.value()]
 
@@ -558,7 +558,7 @@ class ExportActionBox(ActionBox):
         super().create_ui_rules()
 
     def set_results(self):
-        _, _, asvd, mli, chords, stdev, airspace_pixels, non_airspace_pixels, _, _, _ = ActionBox.current_results
+        _, _, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels, _, _, _ = ActionBox.current_results
 
         gui_creator.update_line_edit(self.mli_line_edit, mli,
                                      self.box_config_data["MLI_METRIC_LINE_EDIT"], mli)

--- a/src/alveoleye/_boxes.py
+++ b/src/alveoleye/_boxes.py
@@ -558,7 +558,7 @@ class ExportActionBox(ActionBox):
         super().create_ui_rules()
 
     def set_results(self):
-        _, _, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels, _, _, _ = ActionBox.current_results
+        _, _, asvd, mli, chords, stdev, airspace_pixels, non_airspace_pixels, _, _, _ = ActionBox.current_results
 
         gui_creator.update_line_edit(self.mli_line_edit, mli,
                                      self.box_config_data["MLI_METRIC_LINE_EDIT"], mli)

--- a/src/alveoleye/_export_operations.py
+++ b/src/alveoleye/_export_operations.py
@@ -7,9 +7,10 @@ def create_json_data(accumulated_results):
     data = {}
 
     for result in accumulated_results:
-        (file_name, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels,
+        (image_file_name, weights_file_name, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels,
          lines_spin_box_value, min_length_spin_box_value, scale_spin_box_value) = result
-        data[str(file_name)] = {
+        data[str(image_file_name)] = {
+            "Weights": weights_file_name,
             "ASVD": {
                 "asvd": asvd,
                 "airspace_pixels": airspace_pixels,

--- a/src/alveoleye/_export_operations.py
+++ b/src/alveoleye/_export_operations.py
@@ -31,7 +31,7 @@ def create_json_data(accumulated_results):
 
 
 def create_csv_data(accumulated_results):
-    field_names = ["File Name", "ASVD", "Airspace Pixels", "Non-Airspace Pixels", "MLI", "Standard Deviation",
+    field_names = ["Image", "Weights", "ASVD", "Airspace Pixels", "Non-Airspace Pixels", "MLI", "Standard Deviation",
                    "Number of Chords", "Lines", "Minimum Length", "Scale"]
 
     csv_buffer = io.StringIO()
@@ -41,15 +41,16 @@ def create_csv_data(accumulated_results):
     written_rows = set()
 
     for result in accumulated_results:
-        (file_name, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels,
+        (image_file_name, weights_file_name, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels,
          lines_spin_box_value, min_length_spin_box_value, scale_spin_box_value) = result
 
-        row_tuple = (file_name, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels, lines_spin_box_value,
-                     min_length_spin_box_value, scale_spin_box_value)
+        row_tuple = (image_file_name, weights_file_name, asvd, mli, stdev, chords, airspace_pixels, non_airspace_pixels,
+                     lines_spin_box_value, min_length_spin_box_value, scale_spin_box_value)
 
         if row_tuple not in written_rows:
             writer.writerow({
-                "File Name": file_name,
+                "Image": image_file_name,
+                "Weights": weights_file_name,
                 "ASVD": asvd,
                 "Airspace Pixels": airspace_pixels,
                 "Non-Airspace Pixels": non_airspace_pixels,

--- a/src/alveoleye/_gui_creator.py
+++ b/src/alveoleye/_gui_creator.py
@@ -1,4 +1,6 @@
 from IPython.external.qt_for_kernel import QtCore
+from PyQt5.QtGui import QCursor
+from PyQt5.QtWidgets import QMessageBox
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (QLineEdit, QDoubleSpinBox, QSpinBox, QHBoxLayout, QSizePolicy,
                              QCheckBox, QPushButton, QFileDialog, QLabel, QLayout)
@@ -173,3 +175,31 @@ def save_data_with_file_dialog():
                                                              "CSV Files (*.csv);;JSON Files (*.json);;All Files (*)")
 
     return file_path, selected_filter
+
+
+def create_confirm_clear_message_box(parent):
+    message_box = QMessageBox(parent)
+    message_box.setIcon(QMessageBox.Warning)
+    message_box.setText(
+        "<html><body style='font-weight: normal;'>Are you sure you want to clear your results?</body></html>")
+
+    buttons = {
+        "Yes": QMessageBox.AcceptRole,
+        "No": QMessageBox.RejectRole
+    }
+
+    button_objects = {}
+
+    for text, role in buttons.items():
+        button = message_box.addButton(text, role)
+        button.setFixedSize(80, 25)
+        button.setCursor(QCursor(Qt.PointingHandCursor))
+        button_objects[text] = button
+
+    message_box.setDefaultButton(button_objects["No"])
+
+    message_box.exec_()
+    clicked_button = message_box.clickedButton()
+
+    return clicked_button == button_objects["Yes"]
+

--- a/src/alveoleye/_workers.py
+++ b/src/alveoleye/_workers.py
@@ -87,7 +87,7 @@ class ProcessingWorker(WorkerParent):
             if not self.terminate:
                 self.results_ready.emit(model_output, inference_labelmap)
         except Exception as e:
-            print(f"Error in postprocessing: {e}")
+            print(f"Error in processing: {e}")
         finally:
             self.finished.emit()
 

--- a/src/alveoleye/dark_theme.css
+++ b/src/alveoleye/dark_theme.css
@@ -72,5 +72,5 @@ ActionButton {
 }
 
 QLabel#divider {
-    background-color: rgba(65, 72, 82);
+    background-color: rgba(65, 72, 82, 1);
 }

--- a/src/alveoleye/light_theme.css
+++ b/src/alveoleye/light_theme.css
@@ -72,5 +72,5 @@ ActionButton {
 }
 
 QLabel#divider {
-    background-color: rgba(215, 210, 207);
+    background-color: rgba(215, 210, 207, 1);
 }

--- a/src/alveoleye/lungcv/assessments.py
+++ b/src/alveoleye/lungcv/assessments.py
@@ -5,13 +5,13 @@ from scipy import ndimage
 
 def calculate_airspace_volume_density(labelmap, labels):
     lumens_mask = np.logical_or(labelmap == labels["AIRWAY_LUMEN"], labelmap == labels["VESSEL_LUMEN"])
-    tissue_map = np.logical_or(labelmap == labels["AIRWAY_EPITHELIUM"], labelmap == labels["VESSEL_ENDOTHELIUM"])
-    mask = np.logical_or(lumens_mask, tissue_map)
-    total_non_lumen_pixels = np.size(labelmap) - np.count_nonzero(mask)
+    epithelium_mask = np.logical_or(labelmap == labels["AIRWAY_EPITHELIUM"], labelmap == labels["VESSEL_ENDOTHELIUM"])
+    mask = np.logical_or(lumens_mask, epithelium_mask)
+    total_non_lumen_or_epithelium_pixels = np.size(labelmap) - np.count_nonzero(mask)
     alveoli_pixels = np.count_nonzero(labelmap == labels["ALVEOLI"])
-    alveolar_density = (alveoli_pixels / total_non_lumen_pixels) * 100.0
+    alveolar_density = (alveoli_pixels / total_non_lumen_or_epithelium_pixels) * 100.0
 
-    return alveolar_density, alveoli_pixels, total_non_lumen_pixels
+    return alveolar_density, alveoli_pixels, total_non_lumen_or_epithelium_pixels
 
 
 def calculate_mean_linear_intercept(labelmap, num_lines, min_length, scale, labels):

--- a/src/alveoleye/lungcv/postprocessor.py
+++ b/src/alveoleye/lungcv/postprocessor.py
@@ -47,9 +47,7 @@ def create_processing_labelmap(model_output, shape, confidence_threshold, labels
 
 
 def create_class_labelmap_from_model(model_output, class_id, confidence_threshold):
-    model_output_mask = np.array([mask.cpu().numpy() for idx, mask in enumerate(model_output["masks"]) if
-                                  (model_output["labels"][idx].cpu().numpy() == class_id and
-                                   model_output["scores"][idx] > confidence_threshold)])
+    model_output_mask = np.array([mask.cpu().numpy() for idx, mask in enumerate(model_output["masks"]) if (model_output["labels"][idx].cpu().numpy() == class_id and model_output["scores"][idx] > confidence_threshold)])
     mask_with_confidence = (model_output_mask > confidence_threshold).any(axis=0)
 
     return mask_with_confidence
@@ -57,15 +55,11 @@ def create_class_labelmap_from_model(model_output, class_id, confidence_threshol
 
 def create_postprocessing_labelmap(masks_labelmap, thresholded_labelmap, labels):
     parenchyma_labelmap = np.where(thresholded_labelmap, labels["ALVEOLI"], labels["PARENCHYMA"])
-    airway_epithelium_labelmap = np.where(masks_labelmap == labels["AIRWAY_EPITHELIUM"],
-                                          labels["AIRWAY_EPITHELIUM"], 0)
-    vessel_epithelium_labelmap = np.where(masks_labelmap == labels["VESSEL_ENDOTHELIUM"],
-                                          labels["VESSEL_ENDOTHELIUM"], 0)
+    airway_epithelium_labelmap = np.where(masks_labelmap == labels["AIRWAY_EPITHELIUM"], labels["AIRWAY_EPITHELIUM"], 0)
+    vessel_epithelium_labelmap = np.where(masks_labelmap == labels["VESSEL_ENDOTHELIUM"], labels["VESSEL_ENDOTHELIUM"], 0)
 
-    airway_complete_labelmap = create_complete_class_labelmap(airway_epithelium_labelmap, thresholded_labelmap,
-                                                              labels["AIRWAY_EPITHELIUM"], labels["AIRWAY_LUMEN"])
-    vessel_complete_labelmap = create_complete_class_labelmap(vessel_epithelium_labelmap, thresholded_labelmap,
-                                                              labels["VESSEL_ENDOTHELIUM"], labels["VESSEL_LUMEN"])
+    airway_complete_labelmap = create_complete_class_labelmap(airway_epithelium_labelmap, thresholded_labelmap, labels["AIRWAY_EPITHELIUM"], labels["AIRWAY_LUMEN"])
+    vessel_complete_labelmap = create_complete_class_labelmap(vessel_epithelium_labelmap, thresholded_labelmap, labels["VESSEL_ENDOTHELIUM"], labels["VESSEL_LUMEN"])
 
     final_labelmap = np.zeros(masks_labelmap.shape, dtype="uint8")
     final_labelmap = np.where(parenchyma_labelmap, parenchyma_labelmap, final_labelmap)
@@ -79,7 +73,6 @@ def create_complete_class_labelmap(class_epithelium_labelmap, thresholded_image,
     all_lumens = cv2.connectedComponents(thresholded_image)[1]
 
     class_epithelium_labelmap = class_epithelium_labelmap.astype(np.uint8).squeeze()
-    outline_labelmap = class_epithelium_labelmap.copy()
     class_epithelium_labelmap_parenchyma_overlap = np.where(thresholded_image, 0, class_epithelium_labelmap)
 
     contours = cv2.findContours(class_epithelium_labelmap, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_TC89_KCOS)[0]
@@ -89,8 +82,7 @@ def create_complete_class_labelmap(class_epithelium_labelmap, thresholded_image,
 
     # Fill edges if the drawn / predicted labels touch the edge
     for contour in contours:
-        contour_mask = cv2.drawContours(np.zeros_like(class_epithelium_labelmap, dtype=np.uint8),
-                                        [contour], -1, 255, thickness=cv2.FILLED)
+        contour_mask = cv2.drawContours(np.zeros_like(class_epithelium_labelmap, dtype=np.uint8), [contour], -1, 255, thickness=cv2.FILLED)
 
         edge_offset = 10
 
@@ -112,8 +104,7 @@ def create_complete_class_labelmap(class_epithelium_labelmap, thresholded_image,
 
     # Run on image considering parenchyma
     for contour in contours:
-        contour_mask = cv2.drawContours(np.zeros_like(class_epithelium_labelmap, dtype=np.uint8),
-                                        [contour], -1, 255, thickness=cv2.FILLED)
+        contour_mask = cv2.drawContours(np.zeros_like(class_epithelium_labelmap, dtype=np.uint8), [contour], -1, 255, thickness=cv2.FILLED)
 
         eroded_contour_mask = cv2.erode(contour_mask, kernel, iterations=1)
 
@@ -128,9 +119,6 @@ def create_complete_class_labelmap(class_epithelium_labelmap, thresholded_image,
             component = all_lumens[centroid_y, centroid_x]
 
             if component:
-                class_epithelium_labelmap[(all_lumens == component) & (eroded_contour_mask == 255)] = lumen_label
-                class_epithelium_labelmap[eroded_contour_mask == 255] = lumen_label
-                # add back in outline
-                class_epithelium_labelmap[outline_labelmap == epithelium_label] = epithelium_label
+                class_epithelium_labelmap_parenchyma_overlap[(all_lumens == component) & (eroded_contour_mask == 255)] = lumen_label
 
-    return class_epithelium_labelmap
+    return class_epithelium_labelmap_parenchyma_overlap


### PR DESCRIPTION
Fixed some small issues with the code:
- Fixed a print statement typo.
- Fixed a problem in which the importation file dialogue did not open up to a consistent or optimal directory.
- Fixed a problem in which exported data included either the weights file name or the image file name depending on which the user imported most recently. Now, export includes both the weights and image file names, and the order remains constant.
- Fixed a problem (that caused some warnings) in which we set RGBA values to 3-length tuples. Added an alpha channel of 1 in every case.
- Fixed a design flaw in which it was extremely easy for users to run the tool on many images, clicking “Add” each time, and then accidentally hit “Clear” and erase all of their work. Added an “Are you sure you want to clear results?” dialogue popup to mitigate that risk.
- Fixed a problem in which the MLI standard deviation field in the GUI displayed the number of chords and vice versa.
- Fixed incorrect variable names