### PR TITLE
Overhauled postprocessing to resolve bugs and better support manual annotation

### DIFF
--- a/src/alveoleye/config.json
+++ b/src/alveoleye/config.json
@@ -117,6 +117,7 @@
     "PARENCHYMA": 18,
     "ALVEOLI": 8,
     "MLI_LINES_INSIDE": 9,
-    "MLI_LINES_OUTSIDE": 24
+    "MLI_LINES_OUTSIDE": 24,
+    "BLOCKER": 1
   }
 }

--- a/src/alveoleye/lungcv/postprocessor.py
+++ b/src/alveoleye/lungcv/postprocessor.py
@@ -47,9 +47,7 @@ def create_processing_labelmap(model_output, shape, confidence_threshold, labels
 
 
 def create_class_labelmap_from_model(model_output, class_id, confidence_threshold):
-    model_output_mask = np.array([mask.cpu().numpy() for idx, mask in enumerate(model_output["masks"]) if
-                                  (model_output["labels"][idx].cpu().numpy() == class_id and
-                                   model_output["scores"][idx] > confidence_threshold)])
+    model_output_mask = np.array([mask.cpu().numpy() for idx, mask in enumerate(model_output["masks"]) if (model_output["labels"][idx].cpu().numpy() == class_id and model_output["scores"][idx] > confidence_threshold)])
     mask_with_confidence = (model_output_mask > confidence_threshold).any(axis=0)
 
     return mask_with_confidence
@@ -57,80 +55,71 @@ def create_class_labelmap_from_model(model_output, class_id, confidence_threshol
 
 def create_postprocessing_labelmap(masks_labelmap, thresholded_labelmap, labels):
     parenchyma_labelmap = np.where(thresholded_labelmap, labels["ALVEOLI"], labels["PARENCHYMA"])
-    airway_epithelium_labelmap = np.where(masks_labelmap == labels["AIRWAY_EPITHELIUM"],
-                                          labels["AIRWAY_EPITHELIUM"], 0)
-    vessel_epithelium_labelmap = np.where(masks_labelmap == labels["VESSEL_ENDOTHELIUM"],
-                                          labels["VESSEL_ENDOTHELIUM"], 0)
+    airway_epithelium_labelmap = np.where(masks_labelmap == labels["AIRWAY_EPITHELIUM"], labels["AIRWAY_EPITHELIUM"], 0)
+    vessel_epithelium_labelmap = np.where(masks_labelmap == labels["VESSEL_ENDOTHELIUM"], labels["VESSEL_ENDOTHELIUM"], 0)
+    blocking_labelmap = np.where(masks_labelmap == labels["BLOCKER"], labels["BLOCKER"], 0)
 
-    airway_complete_labelmap = create_complete_class_labelmap(airway_epithelium_labelmap, thresholded_labelmap,
-                                                              labels["AIRWAY_EPITHELIUM"], labels["AIRWAY_LUMEN"])
-    vessel_complete_labelmap = create_complete_class_labelmap(vessel_epithelium_labelmap, thresholded_labelmap,
-                                                              labels["VESSEL_ENDOTHELIUM"], labels["VESSEL_LUMEN"])
+    airway_complete_labelmap = create_complete_class_labelmap(airway_epithelium_labelmap, thresholded_labelmap, labels["AIRWAY_EPITHELIUM"], labels["AIRWAY_LUMEN"])
+    vessel_complete_labelmap = create_complete_class_labelmap(vessel_epithelium_labelmap, thresholded_labelmap, labels["VESSEL_ENDOTHELIUM"], labels["VESSEL_LUMEN"])
+    blocking_complete_labelmap = create_complete_class_labelmap(blocking_labelmap, thresholded_labelmap, labels["BLOCKER"], 2, True)
 
     final_labelmap = np.zeros(masks_labelmap.shape, dtype="uint8")
     final_labelmap = np.where(parenchyma_labelmap, parenchyma_labelmap, final_labelmap)
     final_labelmap = np.where(airway_complete_labelmap, airway_complete_labelmap, final_labelmap)
     final_labelmap = np.where(vessel_complete_labelmap, vessel_complete_labelmap, final_labelmap)
 
+    final_labelmap = np.where(blocking_complete_labelmap, blocking_complete_labelmap, final_labelmap)
+    final_labelmap[final_labelmap == 2] = 0
+
     return final_labelmap
 
 
-def create_complete_class_labelmap(class_epithelium_labelmap, thresholded_image, epithelium_label, lumen_label):
-    all_lumens = cv2.connectedComponents(thresholded_image)[1]
-
+def create_complete_class_labelmap(class_epithelium_labelmap, thresholded_image, epithelium_label, lumen_label, blocking=False, edge_distance=10):
     class_epithelium_labelmap = class_epithelium_labelmap.astype(np.uint8).squeeze()
-    outline_labelmap = class_epithelium_labelmap.copy()
-    class_epithelium_labelmap_parenchyma_overlap = np.where(thresholded_image, 0, class_epithelium_labelmap)
 
-    contours = cv2.findContours(class_epithelium_labelmap, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_TC89_KCOS)[0]
+    non_tissue_spaces = cv2.connectedComponents(thresholded_image)[1]
 
-    kernel_size = 5
-    kernel = np.ones((kernel_size, kernel_size), np.uint8)
+    labelmap_without_overlap = class_epithelium_labelmap.copy()
+    labelmap_with_overlap = np.where(thresholded_image, 0, class_epithelium_labelmap)
 
-    # Fill edges if the drawn / predicted labels touch the edge
+    contours = cv2.findContours(class_epithelium_labelmap, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
+    height, width = class_epithelium_labelmap.shape
+
     for contour in contours:
-        contour_mask = cv2.drawContours(np.zeros_like(class_epithelium_labelmap, dtype=np.uint8),
-                                        [contour], -1, 255, thickness=cv2.FILLED)
+        x, y, w, h = cv2.boundingRect(contour)
+        x1, y1 = max(0, x), max(0, y)
+        x2, y2 = min(width - 1, x + w), min(height - 1, y + h)
 
-        edge_offset = 10
+        if x1 <= edge_distance:
+            cv2.line(class_epithelium_labelmap, (x1, y1), (x1, y2), epithelium_label, thickness=1)
+        if x2 >= width - edge_distance:
+            cv2.line(class_epithelium_labelmap, (x2, y1), (x2, y2), epithelium_label, thickness=1)
+        if y1 <= edge_distance:
+            cv2.line(class_epithelium_labelmap, (x1, y1), (x2, y1), epithelium_label, thickness=1)
+        if y2 >= height - edge_distance:
+            cv2.line(class_epithelium_labelmap, (x1, y2), (x2, y2), epithelium_label, thickness=1)
 
-        touching_left = np.any(contour_mask[:, :edge_offset] != 0)
-        touching_right = np.any(contour_mask[:, -1 * edge_offset:] != 0)
-        touching_top = np.any(contour_mask[:edge_offset, :] != 0)
-        touching_bottom = np.any(contour_mask[-1 * edge_offset:, :] != 0)
+    contours = cv2.findContours(class_epithelium_labelmap, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
+    kernel = np.ones((5, 5), np.uint8)
 
-        if touching_right:
-            class_epithelium_labelmap[:, -1 * edge_offset:] = epithelium_label
-        if touching_left:
-            class_epithelium_labelmap[:, :edge_offset] = epithelium_label
-        if touching_top:
-            class_epithelium_labelmap[:edge_offset, edge_offset:-1 * edge_offset] = epithelium_label
-        if touching_bottom:
-            class_epithelium_labelmap[-1 * edge_offset:, edge_offset:-1 * edge_offset] = epithelium_label
-
-    contours = cv2.findContours(class_epithelium_labelmap, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_TC89_KCOS)[0]
-
-    # Run on image considering parenchyma
     for contour in contours:
-        contour_mask = cv2.drawContours(np.zeros_like(class_epithelium_labelmap, dtype=np.uint8),
-                                        [contour], -1, 255, thickness=cv2.FILLED)
+        mask = np.zeros_like(class_epithelium_labelmap, dtype=np.uint8)
+        cv2.drawContours(mask, [contour], -1, 255, thickness=cv2.FILLED)
 
-        eroded_contour_mask = cv2.erode(contour_mask, kernel, iterations=1)
+        eroded_mask = cv2.erode(mask, kernel)
+        empty_spaces = cv2.bitwise_and(eroded_mask, cv2.bitwise_not(class_epithelium_labelmap))
 
-        rough_empty_spaces = cv2.bitwise_and(eroded_contour_mask, cv2.bitwise_not(class_epithelium_labelmap))
-        rough_empty_spaces = np.where(rough_empty_spaces == 255, rough_empty_spaces, 0)
+        empty_spaces = np.where(empty_spaces == 255, empty_spaces, 0)
 
-        centroids = cv2.connectedComponentsWithStats(rough_empty_spaces)[3]
+        centroids = cv2.connectedComponentsWithStats(empty_spaces, connectivity=8)[3]
 
-        # Flood fill spaces
-        for centroid in centroids[1:]:
-            centroid_x, centroid_y = map(int, centroid)
-            component = all_lumens[centroid_y, centroid_x]
+        if blocking:
+            labelmap_without_overlap[eroded_mask == 255] = lumen_label
+        else:
+            for centroid in centroids[1:]:
+                cx, cy = map(int, centroid)
+                component = non_tissue_spaces[cy, cx]
+                if component:
+                    labelmap_with_overlap[(non_tissue_spaces == component)] = lumen_label
 
-            if component:
-                class_epithelium_labelmap[(all_lumens == component) & (eroded_contour_mask == 255)] = lumen_label
-                class_epithelium_labelmap[eroded_contour_mask == 255] = lumen_label
-                # add back in outline
-                class_epithelium_labelmap[outline_labelmap == epithelium_label] = epithelium_label
-
-    return class_epithelium_labelmap
+    return labelmap_without_overlap if blocking else labelmap_with_overlap


### PR DESCRIPTION
The code in the “create_complete_class_labelmap” function in the postprocessor.py file will sometimes flood (almost) the entire viewer as if everything is vessel lumen. This problem occurs with image 1.png in src/alveoleye/data/. Steps to replicate: (1) run latest version of AlveolEye (before these changes), (2) select image 1.png, (3) click the “Run Processing” action button, (4) click the “Run Postprocessing” action button.

Further, the current code will also create artifacts along the sides of the viewer on some images. This problem occurs with image 4.png in src/alveoleye/data/, among others. Steps to replicate: same as above, albeit with image 4.png instead of image 1.png.

Finally, the current code will fill a connected component at the center of the image if there are vessel or airway instances along all four edges of the image. Steps to replicate: (1) run latest version of AlveolEye (before these changes), (2) select any image in src/alveoleye/data/ with a component at the center (like 2.png), (3) click the “Run Processing” action button, (4) draw either airways or vessels along each edge of the image such that there are annotations of the same type (airway or vessel) on all four sides, (5) click the “Run Postprocessing” action button.

We previously attempted to resolve such issues by reverting to a previous version of postprocessing.py. However, the old version disabled the user’s ability to “block” regions of the image (from being factored in the assessments) by outlining such regions in either the vessel or airway tissue label. It also did not completely eliminate the bugs. Our new solution resolves each of the aforementioned issues and introduces a new “blocking” label (label 1). With the blocking label, the user can now outline regions to exclude from assessments.

<img width="743" alt="Screenshot 2024-09-13 at 4 38 24 PM" src="https://github.com/user-attachments/assets/dab7dbf2-f98e-4df9-87af-e98d575dbf4c">

<img width="746" alt="Screenshot 2024-09-13 at 4 32 09 PM" src="https://github.com/user-attachments/assets/2ff3d889-06f6-4b72-adce-3f7cec6580e0">

