### PR TITLE
Disabled spinbox scrolling

### DIFF
--- a/src/alveoleye/_gui_creator.py
+++ b/src/alveoleye/_gui_creator.py
@@ -1,12 +1,35 @@
+import os
+import re
+
 from IPython.external.qt_for_kernel import QtCore
-from qtpy.QtGui import QCursor
-from qtpy.QtWidgets import QMessageBox
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (QLineEdit, QDoubleSpinBox, QSpinBox, QHBoxLayout, QSizePolicy,
-                            QCheckBox, QPushButton, QFileDialog, QLabel, QLayout)
+from qtpy.QtGui import QCursor
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QSpinBox,
+    QDoubleSpinBox
+)
 
-from pathlib import Path
+class NoScrollSpinBox(QSpinBox):
+    def wheelEvent(self, event):
+        event.ignore()
 
+class NoScrollDoubleSpinBox(QDoubleSpinBox):
+    def wheelEvent(self, event):
+        event.ignore()
 
 def create_sub_layout(layout, elements):
     for element in elements:
@@ -16,21 +39,20 @@ def create_sub_layout(layout, elements):
             layout.addWidget(element)
     return layout
 
-
 def create_label_and_spin_box_layout(label_text, tooltip_text, spin_box_min, spin_box_max, spin_box_default,
                                      spin_box_step, spin_box_suffix, value_type="single", decimals=5):
     label = QLineEdit(label_text)
     label.setReadOnly(True)
     label.setObjectName("labelLineEdit")
 
-    spin_box_parameters = {
-        "minimum": spin_box_min,
-        "maximum": spin_box_max,
-        "value": spin_box_default,
-        "singleStep": spin_box_step,
-        "suffix": spin_box_suffix
-    }
-    spin_box = QDoubleSpinBox(**spin_box_parameters) if value_type == "double" else QSpinBox(**spin_box_parameters)
+    spin_box_cls = NoScrollDoubleSpinBox if value_type == "double" else NoScrollSpinBox
+    spin_box = spin_box_cls()
+    spin_box.setMinimum(spin_box_min)
+    spin_box.setMaximum(spin_box_max)
+    spin_box.setValue(spin_box_default)
+    spin_box.setSingleStep(spin_box_step)
+    spin_box.setSuffix(spin_box_suffix)
+
     if value_type == "double":
         spin_box.setDecimals(decimals)
 
@@ -45,7 +67,6 @@ def create_label_and_spin_box_layout(label_text, tooltip_text, spin_box_min, spi
 
     return label_and_spin_box_layout, label, spin_box
 
-
 def create_check_box_widget(check_box_text, on_check_box_checked, check_box_tooltip_text, default_checked=False):
     check_box = QCheckBox(check_box_text)
     check_box.setChecked(default_checked)
@@ -55,21 +76,20 @@ def create_check_box_widget(check_box_text, on_check_box_checked, check_box_tool
 
     return check_box
 
-
 def create_check_box_and_spin_box_layout(check_box_text, check_box_tooltip_text, spin_box_tooltip_text,
                                          on_check_box_checked, spin_box_min, spin_box_max, spin_box_default,
                                          spin_box_step, spin_box_suffix="", value_type="single", decimals=5):
     check_box = QCheckBox(check_box_text)
     check_box.stateChanged.connect(on_check_box_checked)
 
-    spin_box_parameters = {
-        "minimum": spin_box_min,
-        "maximum": spin_box_max,
-        "value": spin_box_default,
-        "singleStep": spin_box_step,
-        "suffix": spin_box_suffix
-    }
-    spin_box = QDoubleSpinBox(**spin_box_parameters) if value_type == "double" else QSpinBox(**spin_box_parameters)
+    spin_box_cls = NoScrollDoubleSpinBox if value_type == "double" else NoScrollSpinBox
+    spin_box = spin_box_cls()
+    spin_box.setMinimum(spin_box_min)
+    spin_box.setMaximum(spin_box_max)
+    spin_box.setValue(spin_box_default)
+    spin_box.setSingleStep(spin_box_step)
+    spin_box.setSuffix(spin_box_suffix)
+
     if value_type == "double":
         spin_box.setDecimals(decimals)
 
@@ -85,7 +105,6 @@ def create_check_box_and_spin_box_layout(check_box_text, check_box_tooltip_text,
     spin_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
     return check_box_and_spin_box_layout, check_box, spin_box
-
 
 def create_check_box_and_line_edit_layout(check_box_text, tooltip_text, on_check_box_checked, line_edit_text):
     check_box = QCheckBox(check_box_text)
@@ -104,7 +123,6 @@ def create_check_box_and_line_edit_layout(check_box_text, tooltip_text, on_check
     line_edit.setCursorPosition(0)
 
     return check_box_and_line_edit_layout, check_box, line_edit
-
 
 def create_button_and_line_edit_layout(button_text, tooltip_text, on_button_pressed, line_edit_text):
     button = QPushButton(button_text)
@@ -126,7 +144,6 @@ def create_button_and_line_edit_layout(button_text, tooltip_text, on_button_pres
 
     return button_and_line_edit_layout, button, line_edit
 
-
 def create_label_and_button_layout(label_text, button_text, tooltip_text, on_button_pressed):
     label = QLineEdit(label_text)
     label.setObjectName("labelLineEdit")
@@ -143,7 +160,6 @@ def create_label_and_button_layout(label_text, button_text, tooltip_text, on_but
     label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
     return label_and_button_layout, label, button
-
 
 def create_label_and_line_edit_layout(label_text, line_edit_text):
     label = QLineEdit(label_text)
@@ -162,42 +178,17 @@ def create_label_and_line_edit_layout(label_text, line_edit_text):
 
     return label_and_line_edit_layout, label, line_edit
 
-
 def update_line_edit(line_edit, value, default, condition):
     if condition:
         line_edit.setText(value)
     else:
         line_edit.setText(default)
 
-
 def create_horizontal_line_widget():
     horizontal_line = QLabel()
     horizontal_line.setFixedHeight(1)
     horizontal_line.setObjectName("divider")
     return horizontal_line
-
-
-def save_data_with_file_dialog(save_location):
-    options = QFileDialog.Options()
-    options |= QFileDialog.DontUseNativeDialog
-    file_dialog = QFileDialog()
-    file_dialog.setOptions(options)
-    file_dialog.setWindowTitle("Save Data")
-
-    file_dialog.setDefaultSuffix("csv")
-    file_dialog.setNameFilter("CSV Files (*.csv);;JSON Files (*.json);;All Files (*)")
-
-    save_path = str(Path.home() / save_location)
-
-    file_path, selected_filter = file_dialog.getSaveFileName(
-        None,
-        'Save File',
-        save_path,
-        "CSV Files (*.csv);;JSON Files (*.json);;All Files (*)"
-    )
-
-    return file_path, selected_filter
-
 
 def create_confirmation_message_box(parent, message):
     message_box = QMessageBox(parent)
@@ -225,7 +216,6 @@ def create_confirmation_message_box(parent, message):
 
     return clicked_button == button_objects["Yes"]
 
-
 def toggle(state, elements):
     if not isinstance(elements, list):
         elements = [elements]
@@ -239,3 +229,96 @@ def toggle(state, elements):
                     stack.append(current.itemAt(i).widget())
             else:
                 current.setEnabled(state)
+
+class ExportDialog(QDialog):
+    def __init__(self, parent=None, default_parent_folder: str = None, has_labelmaps: bool = True):
+        super().__init__(parent)
+        self.setWindowTitle("Export Results")
+        self.setMinimumWidth(400)
+
+        self._default_parent = default_parent_folder or os.getcwd()
+        self.has_labelmaps = has_labelmaps
+
+        self.build_ui()
+
+    def build_ui(self):
+        self.parent_le = QLineEdit(self._default_parent)
+        browse = QPushButton("Browse…")
+        browse.clicked.connect(self._on_browse_parent)
+
+        h1 = QHBoxLayout()
+        h1.addWidget(self.parent_le)
+        h1.addWidget(browse)
+
+        self.project_le = QLineEdit("results")
+
+        self.metrics_combo = QComboBox(self)
+        self.metrics_combo.addItems(["csv", "json"])
+
+        form = QFormLayout()
+        form.addRow("Parent folder:", h1)
+        form.addRow("Project name:", self.project_le)
+        form.addRow("Metrics format:", self.metrics_combo)
+
+        if self.has_labelmaps:
+            self.labelmap_combo = QComboBox(self)
+            self.labelmap_combo.addItems(["tif", "png"])
+            self.rgb_cb = QCheckBox("Export as RGB image")
+            self.zip_cb = QCheckBox("Compress into ZIP archive")
+
+            form.addRow("Labelmap format:", self.labelmap_combo)
+            form.addRow("", self.rgb_cb)
+            form.addRow("", self.zip_cb)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self._on_accept)
+        buttons.rejected.connect(self.reject)
+
+        v = QVBoxLayout()
+        v.addLayout(form)
+        v.addWidget(buttons)
+        self.setLayout(v)
+
+    def get_values(self):
+        return (
+            self.parent_le.text().strip(),
+            self.project_le.text().strip(),
+            self.metrics_combo.currentText(),
+            self.labelmap_combo.currentText() if self.has_labelmaps else None,
+            self.rgb_cb.isChecked() if self.has_labelmaps else False,
+            self.zip_cb.isChecked() if self.has_labelmaps else False,
+        )
+
+    def _on_browse_parent(self):
+        start = self.parent_le.text().strip() or self._default_parent
+        chosen = QFileDialog.getExistingDirectory(
+            self,
+            "Select Parent Folder",
+            start,
+            QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks
+        )
+        if chosen:
+            self.parent_le.setText(chosen)
+
+    def _on_accept(self):
+        p = self.parent_le.text().strip()
+        if not p or not os.path.isdir(p) or not os.access(p, os.W_OK):
+            QMessageBox.warning(self,
+                                "Invalid Folder",
+                                "Please pick an existing, writable folder.")
+            return
+
+        name = self.project_le.text().strip()
+        if not name or re.search(r"[\\/]", name):
+            QMessageBox.warning(self,
+                                "Invalid Name",
+                                "Enter a non‐empty name without slashes.")
+            return
+
+        self.accept()
+
+def get_export_params(parent=None, default_parent_folder: str = None, has_labelmaps: bool = True):
+    dlg = ExportDialog(parent, default_parent_folder=default_parent_folder, has_labelmaps=has_labelmaps)
+    if dlg.exec_() == QDialog.Accepted:
+        return dlg.get_values()
+    return None


### PR DESCRIPTION
This PR overrides the QSpinBox and QDoubleSpinBox classes to disable their wheel events. The new spin boxes ignore scroll input to prevent unintentional value changes when the user scrolls over the widget.